### PR TITLE
Add randomized exponential backoff

### DIFF
--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -103,7 +103,7 @@ export function _awaitExponentialBackoff (attempts) {
   if (attempts === 1) {
     return Promise.resolve();
   }
-  
+
   return Promise.delay((Math.pow(2, attempts - 1) + (Math.random() - 0.3)) * 1000);
 }
 

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -45,6 +45,7 @@ export function oauthRequest (options, attempts = 1) {
   return Promise.resolve()
     .then(() => this._awaitRatelimit())
     .then(() => this._awaitRequestDelay())
+    .then(() => _awaitExponentialBackoff(attempts))
     .then(() => this.updateAccessToken())
     .then(token => {
       return this.rawRequest(merge({
@@ -96,6 +97,14 @@ export function oauthRequest (options, attempts = 1) {
       }
       throw e;
     });
+}
+
+export function _awaitExponentialBackoff (attempts) {
+  if (attempts === 1) {
+    return Promise.resolve();
+  }
+  
+  return Promise.delay((Math.pow(2, attempts - 1) + (Math.random() - 0.3)) * 1000);
 }
 
 export function _awaitRatelimit () {

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -271,7 +271,7 @@ describe('snoowrap', function () {
       await r._awaitExponentialBackoff(3);
       end = Date.now();
       expect(end - start).to.be.within(3600, 4800);
-    })
+    });
   });
 
   describe('general snoowrap behavior', () => {

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -256,6 +256,22 @@ describe('snoowrap', function () {
       expect(inspected).to.be.a('string');
       expect(_.includes(inspected, "author: RedditUser { name: 'not_an_aardvark' }")).to.be.true();
     });
+    it('does exponential backoff', async function() {
+      let start = Date.now();
+      await r._awaitExponentialBackoff(1);
+      let end = Date.now();
+      expect(end - start).to.be.lessThan(10); // let's be generous
+
+      start = Date.now();
+      await r._awaitExponentialBackoff(2);
+      end = Date.now();
+      expect(end - start).to.be.within(1.6, 2.8);
+
+      start = Date.now();
+      await r._awaitExponentialBackoff(3);
+      end = Date.now();
+      expect(end - start).to.be.within(3.6, 4.8);
+    })
   });
 
   describe('general snoowrap behavior', () => {

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -256,21 +256,21 @@ describe('snoowrap', function () {
       expect(inspected).to.be.a('string');
       expect(_.includes(inspected, "author: RedditUser { name: 'not_an_aardvark' }")).to.be.true();
     });
-    it('does exponential backoff', async function() {
+    it('does exponential backoff', async () => {
       let start = Date.now();
       await r._awaitExponentialBackoff(1);
       let end = Date.now();
-      expect(end - start).to.be.lessThan(10); // let's be generous
+      expect(end - start).to.be.lessThan(500);
 
       start = Date.now();
       await r._awaitExponentialBackoff(2);
       end = Date.now();
-      expect(end - start).to.be.within(1.6, 2.8);
+      expect(end - start).to.be.within(1600, 2800);
 
       start = Date.now();
       await r._awaitExponentialBackoff(3);
       end = Date.now();
-      expect(end - start).to.be.within(3.6, 4.8);
+      expect(end - start).to.be.within(3600, 4800);
     })
   });
 


### PR DESCRIPTION
So my bots were blocked. After emailing them...

> Hello,
> 
> You were blocked because your bots were triggering an error on our end and were not backing off. In general, if there is an error response (5XX status code, or 429) you should do an exponential backoff in order to reduce load on the site. I've removed the block from your IP.
> 
> Ricky

Hopefully I did this the right way...