### PR TITLE
Make documentation examples more idiomatic #103

### DIFF
--- a/src/objects/Listing.js
+++ b/src/objects/Listing.js
@@ -109,12 +109,14 @@ const Listing = class Listing extends Array {
   query parameter), then the newly-fetched elements will appear at the beginning. In any case, continuity is maintained, i.e.
   the order of items in the Listing will be the same as the order in which they appear on reddit.
   * @example
-  * r.getHot({limit: 25}).then(myListing => {
+  * r.getHot({limit: 25})
+  * .then(myListing => {
   *   console.log(myListing.length); // => 25
-  *   myListing.fetchMore({amount: 10}).then(extendedListing => {
-  *     console.log(extendedListing.length); // => 35
-  *   })
+  *   return myListing.fetchMore({amount: 10})
   * });
+  * .then(extendedListing => {
+  *   console.log(extendedListing.length); // => 35
+  * })
   */
   fetchMore (options) {
     const parsedOptions = defaults(

--- a/src/objects/RedditContent.js
+++ b/src/objects/RedditContent.js
@@ -37,7 +37,8 @@ const RedditContent = class RedditContent {
   function is called again. To refresh an object, use refresh().
   * @example
   *
-  * r.getUser('not_an_aardvark').fetch().then(userInfo => {
+  * r.getUser('not_an_aardvark').fetch()
+  * .then(userInfo => {
   *   console.log(userInfo.name); // 'not_an_aardvark'
   *   console.log(userInfo.created_utc); // 1419104352
   * });

--- a/src/objects/ReplyableContent.js
+++ b/src/objects/ReplyableContent.js
@@ -78,7 +78,8 @@ const ReplyableContent = class ReplyableContent extends RedditContent {
   * @returns {Promise} A Promise that fulfills with this message after the request is complete
   * @example
   *
-  * r.getInbox({limit: 1}).then(messages =>
+  * r.getInbox({limit: 1})
+  * .then(messages =>
   *   messages[0].blockAuthor();
   * );
   */

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -199,10 +199,11 @@ const snoowrap = class snoowrap {
   *   redirectUri: 'example.com'
   * }).then(r => {
   *   // Now we have a requester that can access reddit through the user's account
-  *   return r.getHot().then(posts => {
-  *     // do something with posts from the front page
-  *   });
+  *   return r.getHot()
   * })
+  * .then(posts => {
+  *   // do something with posts from the front page
+  * });
   */
   static fromAuthCode ({
     code = requiredArg('code'),
@@ -871,7 +872,8 @@ const snoowrap = class snoowrap {
   * @returns {Promise} A Promise that resolves when the request is complete
   * @example
   *
-  * r.readAllMessages().then(function () {
+  * r.readAllMessages()
+  * .then(function () {
   *   r.getUnreadMessages().then(console.log)
   * })
   * // => Listing []


### PR DESCRIPTION
Promises were changed to the following pattern.
One line: 
```js
doSomething("arg1", {prop: ""}).then(console.log)
```
after multi line object args, one line then: 
```js
doSomething({
  prop: "",
  prop2: ""
}).then(console.log)
```
after non object args, multi line then
```js
doSomething("arg1", {prop: ""})
.then(r => {
  // do more stuff
})
```
after multi line object args, multi line then 
```js
doSomething({
  prop: "",
  prop2: ""
}).then(r => {
  // do more stuff
})
```
chaining thens
```js
doSomething({
  prop: "",
  prop2: ""
}).then(r => {
  return nextPromise
})
.then(r2 => {
  // do more stuff
})
```
```js
doSomething("arg1", {prop: ""})
.then(r => {
  return nextPromise
})
.then(r2 => {
  // do more stuff
})
```