### PR TITLE
Fix example code for snoowrap#submitSelfpost

### DIFF
--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -568,7 +568,7 @@ const snoowrap = class snoowrap {
   * r.submitSelfpost({
   *   subredditName: 'snoowrap_testing',
   *   title: 'This is a selfpost',
-  *   body: 'This is the body of the selfpost'
+  *   text: 'This is the text body of the selfpost'
   * }).then(console.log)
   * // => Submission { name: 't3_4abmsz' }
   * // (new selfpost created on reddit)


### PR DESCRIPTION
The current example uses the key `body` instead of `text` as described in docs. I tried this example and the post would be empty if you use `body`.