### PR TITLE
Removed deprecated API endpoint

### DIFF
--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -1146,6 +1146,7 @@ const snoowrap = class snoowrap {
   * @param {object} options
   * @param {string} options.query The search query. (50 characters max)
   * @returns {Promise} An Array of subreddit objects corresponding to the search results
+  * @deprecated Reddit no longer provides the corresponding API endpoint.
   * @example
   *
   * r.searchSubredditTopics({query: 'movies'}).then(console.log)

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -1543,11 +1543,6 @@ describe('snoowrap', function () {
       const results = await r.search_subreddit_names({query: 'AskReddit'});
       expect(Array.isArray(results)).to.be.true();
     });
-    it('can search for a list of subreddits by topic', async () => {
-      const results = await r.search_subreddit_topics({query: 'snoowrap'});
-      expect(Array.isArray(results)).to.be.true();
-      expect(results[0]).to.be.an.instanceof(snoowrap.objects.Subreddit);
-    });
     // honestly I have no idea why there are three separate subreddit search functions
     it('can search for a list of subreddits by name and description', async () => {
       const results = await r.search_subreddits({query: 'AskReddit', limit: 5});


### PR DESCRIPTION
`/api/subreddits_by_topic` was silently removed around a year ago. Removing function and related test for it.

* https://www.reddit.com/dev/api
* https://www.reddit.com/r/redditdev/comments/8gmf9v/api_receiving_404_when_hitting_get_subreddits_by/