### PR TITLE
Make sure accessToken or refreshToken is always a string

### DIFF
--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -78,8 +78,8 @@ const snoowrap = class snoowrap {
     if (!userAgent && !isBrowser) {
       return requiredArg('userAgent');
     }
-    if (!accessToken &&
-        (clientId === undefined || clientSecret === undefined || refreshToken === undefined) &&
+    if ((!accessToken || typeof accessToken !== 'string') &&
+        (clientId === undefined || clientSecret === undefined || typeof refreshToken !== 'string') &&
         (clientId === undefined || clientSecret === undefined || username === undefined || password === undefined)
     ) {
       throw new errors.NoCredentialsError();

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -82,8 +82,18 @@ describe('snoowrap', function () {
     it('does not throw an error if only an access token is provided', () => {
       expect(() => new snoowrap({user_agent: 'a', access_token: 'blah'})).not.to.throw();
     });
+    it('throws an error if the access token is not a string', () => {
+      expect(() => new snoowrap({user_agent: 'a', access_token: {}})).to.throw();
+      expect(() => new snoowrap({user_agent: 'a', access_token: []})).to.throw();
+      expect(() => new snoowrap({user_agent: 'a', access_token: 123})).to.throw();
+    });
     it('does not throw an error if a user_agent, client_id, client_secret, and refresh_token are provided', () => {
       expect(() => new snoowrap({user_agent: 'a', client_id: 'b', client_secret: 'c', refresh_token: 'd'})).not.to.throw();
+    });
+    it('throws an error if refresh_token is not a string', () => {
+      expect(() => new snoowrap({user_agent: 'a', client_id: 'b', client_secret: 'c', refresh_token: {}})).to.throw();
+      expect(() => new snoowrap({user_agent: 'a', client_id: 'b', client_secret: 'c', refresh_token: []})).to.throw();
+      expect(() => new snoowrap({user_agent: 'a', client_id: 'b', client_secret: 'c', refresh_token: 123})).to.throw();
     });
     it('does not throw an error if a user_agent, client_id, client_secret, username, and password are provided', () => {
       expect(() => {


### PR DESCRIPTION
Fixes #171.

To prevent people inputting incorrect types and getting strange error, we now catch it early and let them know it's incorrect.

I used the already existing exception as it fits.