### PR TITLE
fix(Multireddit): Deprecated rename. Changed edit to rename display name

### DIFF
--- a/src/objects/MultiReddit.js
+++ b/src/objects/MultiReddit.js
@@ -45,6 +45,7 @@ const MultiReddit = class MultiReddit extends RedditContent {
   * @param {string} options.newName The new name for this multireddit.
   * @returns {Promise} A Promise that fulfills with this multireddit
   * @example r.getUser('multi-mod').getMultireddit('coding_languages').copy({newName: 'cookie_languages '})
+  * @deprecated Reddit no longer provides the corresponding API endpoint. Please use `edit()` with a new name.
   */
   rename ({new_name, newName = new_name}) {
     return this._r._getMyName().then(name => this._post({
@@ -58,7 +59,7 @@ const MultiReddit = class MultiReddit extends RedditContent {
   * @summary Edits the properties of this multireddit.
   * @desc **Note**: Any omitted properties here will simply retain their previous values.
   * @param {object} options
-  * @param {string} [options.name] The name of the new multireddit. 50 characters max
+  * @param {string} [options.name] The name of the new multireddit. 50 characters max.
   * @param {string} [options.description] A description for the new multireddit, in markdown.
   * @param {string} [options.visibility] The multireddit's visibility setting. One of `private`, `public`, `hidden`.
   * @param {string} [options.icon_name] One of `art and design`, `ask`, `books`, `business`, `cars`, `comics`, `cute animals`,
@@ -70,10 +71,11 @@ const MultiReddit = class MultiReddit extends RedditContent {
   * @returns {Promise} The updated version of this multireddit
   * @example r.getUser('not_an_aardvark').getMultireddit('cookie_languages').edit({visibility: 'hidden'})
   */
-  edit ({description, icon_name, key_color, visibility, weighting_scheme}) {
+  edit ({name = '', description, icon_name, key_color, visibility, weighting_scheme}) {
+    const display_name = name.length ? name : this.name;
     return this._put({uri: `api/multi${this._path}`, form: {model: JSON.stringify({
       description_md: description,
-      display_name: this.name,
+      display_name,
       icon_name,
       key_color,
       visibility,

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -1782,7 +1782,8 @@ describe('snoowrap', function () {
       expect(multis).to.be.an.instanceof(Array);
       expect(multis[0]).to.be.an.instanceof(snoowrap.objects.MultiReddit);
     });
-    it('can rename a multireddit', async () => {
+    // deprecated endpoint
+    it.skip('can rename a multireddit', async () => {
       const new_name = require('crypto').randomBytes(8).toString('hex');
       await my_multi.rename({new_name});
       expect(my_multi.name).to.equal(new_name);
@@ -1793,8 +1794,13 @@ describe('snoowrap', function () {
       expect(new_multi.name).to.equal(multi_name);
       expect(_.map(new_multi.subreddits, 'display_name').sort()).to.eql(['Cookies', 'snoowrap_testing']);
     });
+    it('can rename a multireddit\'s display name', async () => {
+      const new_name = require('crypto').randomBytes(8).toString('hex');
+      const edited_multi = await my_multi.edit({name: new_name});
+      expect(edited_multi.display_name).to.equal(new_name);
+    });
     it('can delete a multireddit', async () => {
-      // Deleting a multi seems to randomly fail on reddit's end sometimes, even when it returns a 200 response.
+      // Deleting a multi seems to randomly fail on Reddit's end sometimes, even when it returns a 200 response.
       const new_name = require('crypto').randomBytes(8).toString('hex');
       const temp_multi = await my_multi.copy({new_name});
       await temp_multi.delete();


### PR DESCRIPTION
fixes #186

Reddit deprecated editing the name of a multireddit with their rebranding from multireddit to custom feed.

Added possibility to edit display name of a multireddit instead, which does not change the URL name of the multi.