### PR TITLE
Adds in the ability to get multiple posts by id and fixes #164

### DIFF
--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -769,6 +769,20 @@ const snoowrap = class snoowrap {
   getNewComments (subredditName, options) {
     return this._getSortedFrontpage('comments', subredditName, options);
   }
+  
+  
+  /**
+   *  @summary Get list of content by IDs.
+   *  @param {string[]} ids An array of fullname IDs you want to fetch the content of.
+   *  @returns {Promise} A listing of content requested, can be any class fetchable by API. e.g. Comment, Submission
+  */
+  getContentByIDs (ids) {
+    if (!/t(1|3)_/g.test(ids)) {
+      throw new errors.InvalidMethodCallError('No valid IDs provided.');
+    }
+    return this._promiseWrap(this.oauthRequest({uri: '/api/info', method: 'get', qs: {id: ids.join(',')}}));
+  }
+
 
   /**
    * @summary Gets a single random Submission.

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -773,14 +773,23 @@ const snoowrap = class snoowrap {
   
   /**
    *  @summary Get list of content by IDs.
-   *  @param {string[]} ids An array of fullname IDs you want to fetch the content of.
+   *  @param {Array<string|Submission|Comment>} ids An array of fullname IDs you want to fetch the content of.
    *  @returns {Promise} A listing of content requested, can be any class fetchable by API. e.g. Comment, Submission
   */
-  getContentByIDs (ids) {
-    if (!/t(1|3)_/g.test(ids)) {
-      throw new errors.InvalidMethodCallError('No valid IDs provided.');
+  getContentByIds (ids) {
+    if (typeof ids[0] === 'object') {
+      if ('name' in ids[0]) {
+        const objectId = [];
+        for (let i = 0; i < ids.length; i++) {
+          objectId.push(ids[i].name);
+        }
+        ids = objectId;
+      }
     }
-    return this._promiseWrap(this.oauthRequest({uri: '/api/info', method: 'get', qs: {id: ids.join(',')}}));
+    if (!/t(1|3)_/g.test(ids)) {
+      throw new TypeError('Invalid argument: List of IDs need to be fullnames.');
+    }
+    return this._get({uri: '/api/info', method: 'get', qs: {id: ids.join(',')}});
   }
 
 

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -1079,33 +1079,21 @@ describe('snoowrap', function () {
       expect(list3).to.have.lengthOf(2);
       expect(list3.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
     });
-    it('can get multiple posts by fullname id', async () => {
-      const posts = await r.getContentByIds(['t3_9l9vof', 't3_9la341']);
-      expect(posts).to.have.lengthOf(2);
-      expect(posts.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
+    it('can get a post and a comment by fullname id', async () => {
+      const listing = await r.getContentByIds(['t3_9l9vof', 't1_erx7tl8']);
+      expect(listing).to.have.lengthOf(2);
+      expect(listing[0] instanceof snoowrap.objects.Submission).to.be.true();
+      expect(listing[1] instanceof snoowrap.objects.Comment).to.be.true();
     });
-    it('can get multiple posts by submission object', async () => {
-      const posts = await r.getContentByIds([r.getSubmission('9l9vof'), r.getSubmission('9la341')]);
-      expect(posts).to.have.lengthOf(2);
-      expect(posts.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
-    });
-    it('can get multiple comments by fullname id', async () => {
-      const comments = await r.getContentByIds(['t1_erx7rym', 't1_erx7tl8']);
-      expect(comments).to.have.lengthOf(2);
-      expect(comments.every(comment => comment instanceof snoowrap.objects.Comment)).to.be.true();
-    });
-    it('can get multiple comments by comment object', async () => {
-      const comments = await r.getContentByIds([r.getComment('erx7rym'), r.getComment('erx7tl8')]);
-      expect(comments).to.have.lengthOf(2);
-      expect(comments.every(comment => comment instanceof snoowrap.objects.Comment)).to.be.true();
+    it('can get a post and a comment by submission and comment object', async () => {
+      const listing = await r.getContentByIds([r.getSubmission('9l9vof'), r.getComment('erx7tl8')]);
+      expect(listing).to.have.lengthOf(2);
+      expect(listing[0] instanceof snoowrap.objects.Submission).to.be.true();
+      expect(listing[1] instanceof snoowrap.objects.Comment).to.be.true();
     });
     it('cant get multiple posts by regular id', async () => {
       const posts = () => r.getContentByIds(['9l9vof', '9la341']);
       expect(await posts).to.throw(TypeError);
-    });
-    it('cant get multiple comments by regular id', async () => {
-      const comments = () => r.getContentByIds(['erx7rym', 'erx7tl8']);
-      expect(await comments).to.throw(TypeError);
     });
   });
 

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -1079,6 +1079,10 @@ describe('snoowrap', function () {
       expect(list3).to.have.lengthOf(2);
       expect(list3.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
     });
+    it('can get multiple posts by fullname id', async () => {
+      const posts = await r.getContentByIDs(['t3_9l9vof', 't3_9la341']);
+      expect(posts.length).to.be.greaterThan(1);
+    });
   });
 
   describe('self-property fetching', () => {

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -1080,8 +1080,32 @@ describe('snoowrap', function () {
       expect(list3.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
     });
     it('can get multiple posts by fullname id', async () => {
-      const posts = await r.getContentByIDs(['t3_9l9vof', 't3_9la341']);
-      expect(posts.length).to.be.greaterThan(1);
+      const posts = await r.getContentByIds(['t3_9l9vof', 't3_9la341']);
+      expect(posts).to.have.lengthOf(2);
+      expect(posts.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
+    });
+    it('can get multiple posts by submission object', async () => {
+      const posts = await r.getContentByIds([r.getSubmission('9l9vof'), r.getSubmission('9la341')]);
+      expect(posts).to.have.lengthOf(2);
+      expect(posts.every(post => post instanceof snoowrap.objects.Submission)).to.be.true();
+    });
+    it('can get multiple comments by fullname id', async () => {
+      const comments = await r.getContentByIds(['t1_erx7rym', 't1_erx7tl8']);
+      expect(comments).to.have.lengthOf(2);
+      expect(comments.every(comment => comment instanceof snoowrap.objects.Comment)).to.be.true();
+    });
+    it('can get multiple comments by comment object', async () => {
+      const comments = await r.getContentByIds([r.getComment('erx7rym'), r.getComment('erx7tl8')]);
+      expect(comments).to.have.lengthOf(2);
+      expect(comments.every(comment => comment instanceof snoowrap.objects.Comment)).to.be.true();
+    });
+    it('cant get multiple posts by regular id', async () => {
+      const posts = () => r.getContentByIds(['9l9vof', '9la341']);
+      expect(await posts).to.throw(TypeError);
+    });
+    it('cant get multiple comments by regular id', async () => {
+      const comments = () => r.getContentByIds(['erx7rym', 'erx7tl8']);
+      expect(await comments).to.throw(TypeError);
     });
   });
 


### PR DESCRIPTION
Add in method to get multiple posts or comments by ID. These IDs do need to be fullname IDs to work. 

(sorry, this is my first commit in this project, so I may have done something wrong! Thanks!)

(fixes #164 )