### PR TITLE
WIP-ish: New modmail types

### DIFF
--- a/src/objects/ModmailConversation.d.ts
+++ b/src/objects/ModmailConversation.d.ts
@@ -1,0 +1,87 @@
+import Subreddit from './Subreddit';
+import RedditContent from './RedditContent';
+import RedditUser from './RedditUser';
+import ModmailConversationAuthor from './ModmailConversationAuthor';
+
+export enum conversationStates {
+    New = 0,
+    InProgress = 1,
+    Archived = 2,
+}
+
+export enum modActionStates {
+    Highlight = 0,
+    UnHighlight = 1,
+    Archive = 2,
+    UnArchive = 3,
+    ReportedToAdmins = 4,
+    Mute = 5,
+    Unmute = 6,
+}
+
+export interface ModmailMessage {
+    body: string;
+    bodyMarkdown: string;
+    author: RedditUser;
+    isInternal: boolean;
+    date: string;
+    id: string;
+}
+
+export interface Author {
+    isMod: boolean;
+    isAdmin: boolean;
+    name: string;
+    isOp: boolean;
+    isParticipant: boolean;
+    isHidden: boolean;
+    id: any;
+    isDeleted: boolean;
+}
+
+export interface Owner {
+    displayName: string;
+    type: string;
+    id: string;
+}
+
+export interface ObjId {
+    id: string;
+    key: string;
+}
+
+export default class ModmailConversation extends RedditContent<ModmailConversation> {
+    static conversationStates: conversationStates;
+    static modActionStats: modActionStates;
+
+    isAuto: boolean;
+    objIds: ObjId[];
+    isRepliable: boolean;
+    lastUserUpdate?: any;
+    isInternal: boolean;
+    lastModUpdate: Date;
+    lastUpdated: Date;
+    authors: Author[];
+    // sometimes an Owner, sometimes a Subreddit
+    owner: Owner | Subreddit;
+    id: string;
+    isHighlighted: boolean;
+    subject: string;
+    participant: ModmailConversationAuthor;
+    state: number;
+    lastUnread?: any;
+    numMessages: number;
+
+    getParticipant(): Promise<ModmailConversationAuthor>;
+
+    isRead(): boolean;
+
+    read(): Promise<this>;
+    unread(): Promise<this>;
+    mute(): Promise<this>;
+    unmute(): Promise<this>;
+    highlight(): Promise<this>;
+    unhighlight(): Promise<this>;
+    archive(): Promise<this>;
+    unarchive(): Promise<this>;
+}

--- a/src/objects/ModmailConversationAuthor.d.ts
+++ b/src/objects/ModmailConversationAuthor.d.ts
@@ -1,0 +1,40 @@
+import Subreddit from './Subreddit';
+import RedditContent from './RedditContent';
+import RedditUser from './RedditUser';
+
+export interface BanStatus {
+    endDate?: string | null;
+    reason: string;
+    isBanned: boolean;
+    isPermanent: boolean;
+}
+
+// TODO: I couldn't find any definitions for this, nor
+// get the field to appear in testing
+export type RecentPost = any;
+
+export interface RecentConvo {
+    date: Date;
+    permalink: string;
+    id: string;
+    subject: string;
+}
+
+export default class ModmailConversationAuthor extends RedditContent<ModmailConversationAuthor> {
+    name: string;
+    isMod?: boolean;
+    isAdmin?: boolean;
+    isOp?: boolean;
+    isParticipant?: boolean;
+    isHidden?: boolean;
+    isDeleted?: boolean;
+
+    // these fields only show up sometimes
+    banStatus?: BanStatus;
+    isSuspended?: boolean;
+    isShadowBanned?: boolean;
+    recentPosts?: { [id: string]: RecentPost };
+    recentConvos?: { [id: string]: RecentConvo };
+
+    getUser(): Promise<RedditUser>;
+}

--- a/src/objects/ModmailConversationAuthor.d.ts
+++ b/src/objects/ModmailConversationAuthor.d.ts
@@ -9,15 +9,24 @@ export interface BanStatus {
     isPermanent: boolean;
 }
 
-// TODO: I couldn't find any definitions for this, nor
-// get the field to appear in testing
-export type RecentPost = any;
+export interface RecentPost {
+    date: string;
+    permalink: string;
+    title: string;
+}
 
 export interface RecentConvo {
-    date: Date;
+    date: string;
     permalink: string;
     id: string;
     subject: string;
+}
+
+export interface RecentComment {
+    date: string;
+    permalink: string;
+    title: string;
+    comment: string;
 }
 
 export default class ModmailConversationAuthor extends RedditContent<ModmailConversationAuthor> {
@@ -35,6 +44,7 @@ export default class ModmailConversationAuthor extends RedditContent<ModmailConv
     isShadowBanned?: boolean;
     recentPosts?: { [id: string]: RecentPost };
     recentConvos?: { [id: string]: RecentConvo };
+    recentComments?: { [id: string]: RecentComment };
 
     getUser(): Promise<RedditUser>;
 }

--- a/src/objects/index.d.ts
+++ b/src/objects/index.d.ts
@@ -1,6 +1,7 @@
 export { default as Comment } from './Comment';
 export { default as Listing, ListingOptions, SortedListingOptions } from './Listing';
 export { default as LiveThread, LiveThreadSettings } from './LiveThread';
+export { default as ModmailConversation } from "./ModmailConversation";
 export { default as MultiReddit, MultiRedditProperties } from './MultiReddit';
 export { default as PrivateMessage } from './PrivateMessage';
 export { default as RedditContent } from './RedditContent';

--- a/src/snoowrap.d.ts
+++ b/src/snoowrap.d.ts
@@ -79,9 +79,8 @@ declare class Snoowrap {
   getNewModmailConversations(options?: ListingOptions & { entity?: string }): Promise<_Listing<_ModmailConversation>>;
   createModmailDiscussion(options: { body: string, subject: string, srName: string }): Promise<_ModmailConversation>;
   getNewModmailConversation(id: string): Promise<_ModmailConversation>;
-  // TODO
-  markNewModmailConversationsAsRead(convs: _ModmailConversation[]): any;
-  markNewModmailConversationsAsUnread(convs: _ModmailConversation[]): any;
+  markNewModmailConversationsAsRead(convs: _ModmailConversation[]): Promise<void>;
+  markNewModmailConversationsAsUnread(convs: _ModmailConversation[]): Promise<void>;
   getNewModmailSubreddits(): Promise<_Subreddit[]>;
   getUnreadNewModmailConversationsCount(): Promise<{ highlighted: number, notifications: number, archived: number, new: number, inprogress: number, mod: number }>;
   bulkReadNewModmail(subs: Array<_Subreddit | string>, state: 'new'|'inprogress'|'mod'|'notifications'|'archived'|'highlighted'|'all'): Promise<_Listing<_ModmailConversation>>;

--- a/src/snoowrap.d.ts
+++ b/src/snoowrap.d.ts
@@ -12,6 +12,8 @@ import {
   SortedListingOptions,
   LiveThread as _LiveThread,
   LiveThreadSettings,
+  ModmailConversation as _ModmailConversation,
+  ModmailConversation,
   MultiReddit as _MultiReddit,
   MultiRedditProperties,
   PrivateMessage as _PrivateMessage,
@@ -74,6 +76,15 @@ declare class Snoowrap {
   getNew(subredditName?: string, options?: ListingOptions): Promise<_Listing<_Submission>>;
   getNewCaptchaIdentifier(): Promise<string>;
   getNewComments(subredditName?: string, options?: ListingOptions): Promise<_Listing<_Comment>>;
+  getNewModmailConversations(options?: ListingOptions & { entity?: string }): Promise<_Listing<_ModmailConversation>>;
+  createModmailDiscussion(options: { body: string, subject: string, srName: string }): Promise<_ModmailConversation>;
+  getNewModmailConversation(id: string): Promise<_ModmailConversation>;
+  // TODO
+  markNewModmailConversationsAsRead(convs: _ModmailConversation[]): any;
+  markNewModmailConversationsAsUnread(convs: _ModmailConversation[]): any;
+  getNewModmailSubreddits(): Promise<_Subreddit[]>;
+  getUnreadNewModmailConversationsCount(): Promise<{ highlighted: number, notifications: number, archived: number, new: number, inprogress: number, mod: number }>;
+  bulkReadNewModmail(subs: Array<_Subreddit | string>, state: 'new'|'inprogress'|'mod'|'notifications'|'archived'|'highlighted'|'all'): Promise<_Listing<_ModmailConversation>>;
   getNewSubreddits(options?: ListingOptions): Promise<_Listing<_Subreddit>>;
   getOauthScopeList(): Promise<{ [key: string]: { description: string; id: string; name: string } }>;
   getPopularSubreddit(options?: ListingOptions): Promise<_Listing<_Subreddit>>;


### PR DESCRIPTION
This patchset adds TypeScript definitions for New Modmail.

I'm not quite sure if they're complete yet, so merge at your own peril.

Fixes #201