### PR TITLE
Allow custom logger to be supplied via config

### DIFF
--- a/src/create_config.js
+++ b/src/create_config.js
@@ -1,5 +1,27 @@
 import {addSnakeCaseShadowProps} from './helpers.js';
 
+export const consoleLogger = Object.freeze({
+  warn (...args) {
+    // eslint-disable-next-line no-console
+    console.warn('[warning]', ...args);
+  },
+
+  info (...args) {
+    // eslint-disable-next-line no-console
+    console.info('[info]', ...args);
+  },
+
+  debug (...args) {
+    // eslint-disable-next-line no-console
+    console.debug('[info]', ...args);
+  },
+
+  trace (...args) {
+    // eslint-disable-next-line no-console
+    console.trace('[trace]', ...args);
+  }
+});
+
 export default function () {
   const config = Object.create(null);
   config.endpointDomain = 'reddit.com';
@@ -10,7 +32,7 @@ export default function () {
   config.maxRetryAttempts = 3;
   config.warnings = true;
   config.debug = false;
-  config.logger = console;
+  config.logger = consoleLogger;
   config.proxies = true;
 
   return addSnakeCaseShadowProps(config);

--- a/src/create_config.js
+++ b/src/create_config.js
@@ -13,7 +13,7 @@ export const consoleLogger = Object.freeze({
 
   debug (...args) {
     // eslint-disable-next-line no-console
-    console.debug('[info]', ...args);
+    console.debug('[debug]', ...args);
   },
 
   trace (...args) {

--- a/src/create_config.js
+++ b/src/create_config.js
@@ -10,6 +10,7 @@ export default function () {
   config.maxRetryAttempts = 3;
   config.warnings = true;
   config.debug = false;
+  config.logger = console;
   config.proxies = true;
 
   return addSnakeCaseShadowProps(config);

--- a/src/snoowrap.d.ts
+++ b/src/snoowrap.d.ts
@@ -142,6 +142,7 @@ declare namespace Snoowrap {
     maxRetryAttempts?: number;
     warnings?: boolean;
     debug?: boolean;
+    logger?: Pick<typeof console, 'warn' | 'info' | 'debug' | 'trace'>;
     proxies?: boolean;
   }
 

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -361,6 +361,8 @@ const snoowrap = class snoowrap {
    console. These can be disabled by setting this to `false`.
    * @param {boolean} [options.debug=false] If set to true, snoowrap will print out potentially-useful information for debugging
    purposes as it runs.
+   * @param {object} [options.logger=console] By default, snoowrap will log any warnings and debug output to the console.
+   A custom logger object may be supplied via this option; it must expose `warn`, `info`, `debug`, and `trace` functions.
    * @param {boolean} [options.proxies=true] Setting this to `false` disables snoowrap's method-chaining feature. This causes
    the syntax for using snoowrap to become a bit heavier, but allows for consistency between environments that support the ES6
    `Proxy` object and environments that don't. This option is a no-op in environments that don't support the `Proxy` object,
@@ -382,13 +384,13 @@ const snoowrap = class snoowrap {
 
   _warn (...args) {
     if (this._config.warnings) {
-      console.warn('[warning]', ...args); // eslint-disable-line no-console
+      this._config.logger.warn('[warning]', ...args);
     }
   }
 
   _debug (...args) {
     if (this._config.debug) {
-      console.log('[debug]', ...args); // eslint-disable-line no-console
+      this._config.logger.debug('[debug]', ...args);
     }
   }
 

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -384,13 +384,13 @@ const snoowrap = class snoowrap {
 
   _warn (...args) {
     if (this._config.warnings) {
-      this._config.logger.warn('[warning]', ...args);
+      this._config.logger.warn(...args);
     }
   }
 
   _debug (...args) {
     if (this._config.debug) {
-      this._config.logger.debug('[debug]', ...args);
+      this._config.logger.debug(...args);
     }
   }
 


### PR DESCRIPTION
A simple configuration expansion that allows for `console` to be replaced with a custom logger. This allows for snoowrap debug and warning logs to be integrated into arbitrary logging systems.