### PR TITLE
feat: add more submit options

### DIFF
--- a/src/snoowrap.d.ts
+++ b/src/snoowrap.d.ts
@@ -214,6 +214,10 @@ declare namespace Snoowrap {
     sendReplies?: boolean;
     captchaIden?: string;
     captchaResponse?: string;
+    nsfw?: boolean;
+    spoiler?: boolean;
+    flairId?: string;
+    flairText?: string;
   }
 
   export interface SubmitLinkOptions {
@@ -224,6 +228,10 @@ declare namespace Snoowrap {
     resubmit?: boolean;
     captchaIden?: string;
     captchaResponse?: string;
+    nsfw?: boolean;
+    spoiler?: boolean;
+    flairId?: string;
+    flairText?: string;
   }
 
   export interface ComposeMessageParams {

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -668,12 +668,17 @@ const snoowrap = class snoowrap {
     text,
     title,
     url,
-    subreddit_name, subredditName = subreddit_name
+    subreddit_name, subredditName = subreddit_name,
+    nsfw,
+    spoiler,
+    flairId,
+    flairText,
+    ...options
   }) {
     return this._post({
       uri: 'api/submit', form: {
         api_type, captcha: captchaResponse, iden: captchaIden, sendreplies: sendReplies, sr: subredditName, kind, resubmit,
-        crosspost_fullname, text, title, url
+        crosspost_fullname, text, title, url, spoiler, nsfw, flair_id: flairId, flair_text: flairText, ...options
       }
     }).tap(handleJsonErrors(this)).then(result => this.getSubmission(result.json.data.id));
   }


### PR DESCRIPTION
Several submit options were missing, this adds a few booleans `spoiler` and `nsfw`, as well as `flairId` and `flairText`

To handle extra options we add a deconstructor