### PR TITLE
Added missing method in Submission type definition

### DIFF
--- a/src/objects/Submission.d.ts
+++ b/src/objects/Submission.d.ts
@@ -129,6 +129,7 @@ export default class Submission extends VoteableContent<Submission> {
   unmarkNsfw(): Promise<this>;
   unmarkSpoiler(): Promise<this>;
   unsticky(): Promise<this>;
+  submitCrosspost(): Promise<this>;
 }
 
 interface ImagePreviewSource {


### PR DESCRIPTION
Added missing method `submitCrosspost()` to the Submission type definition file.