### PR TITLE
Change ReadableStream to NodeJS.ReadableStream

### DIFF
--- a/src/objects/Subreddit.d.ts
+++ b/src/objects/Subreddit.d.ts
@@ -250,7 +250,7 @@ export interface SubredditSettings {
 }
 
 interface ImageUploadOptions {
-  file: string | ReadableStream;
+  file: string | NodeJS.ReadableStream;
   imageType?: string;
 }
 


### PR DESCRIPTION
This is just a small change that makes it so you can use `snoowrap` with Typescript with an `ESNext` or `ES2019` lib option in the tsconfig