### PR TITLE
fix: export RichTextFlair type

### DIFF
--- a/src/objects/VoteableContent.d.ts
+++ b/src/objects/VoteableContent.d.ts
@@ -2,7 +2,7 @@ import RedditUser from './RedditUser';
 import ReplyableContent from './ReplyableContent';
 import Subreddit from './Subreddit';
 
-interface RichTextFlair {
+export interface RichTextFlair {
   /** The string representation of the emoji */
   a?: string;
   /** The type of the flair entry */


### PR DESCRIPTION
This should be exported as it's imported in `Submission.d.ts`.

https://github.com/not-an-aardvark/snoowrap/blob/62c64fbad3936dc11515f33b6444150947f9790e/src/objects/Submission.d.ts#L5