### PR TITLE
fix: allow installing via git

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "dist/snoowrap.d.ts",
   "scripts": {
     "prepublishOnly": "npm run compile",
+    "prepare": "npm run compile",
     "compile": "npm run type-check && npm run build:babel && npm run build:types && node ./scripts/copyTSTypes.js",
     "lint": "eslint --ignore-path .gitignore . --cache",
     "test": "npm run lint && npm run test:mocha",


### PR DESCRIPTION
Without this change `npm i github:not-an-aardvark/snoowrap` fails as the `compile` script isn't ran.