### PR TITLE
Add ability to sort comments when using `getSubmission`

### DIFF
--- a/src/objects/RedditContent.js
+++ b/src/objects/RedditContent.js
@@ -51,11 +51,12 @@ const RedditContent = class RedditContent {
   */
   fetch () {
     if (!this._fetch) {
+      let getParams = {uri: this._uri}
+      // a submission we want to sort comments with
       if (this.constructor._name === 'Submission' && this.sort) {
-        this._fetch = this._r._promiseWrap(this._r._get({uri: this._uri, qs: { sort: this.sort } }).then(res => this._transformApiResponse(res)));
-      } else {
-        this._fetch = this._r._promiseWrap(this._r._get({uri: this._uri}).then(res => this._transformApiResponse(res)));
+        getParams = {...getParams, qs: { sort: this.sort }}
       }
+      this._fetch = this._r._promiseWrap(this._r._get(getParams).then(res => this._transformApiResponse(res)));
     }
     return this._fetch;
   }

--- a/src/objects/RedditContent.js
+++ b/src/objects/RedditContent.js
@@ -51,7 +51,11 @@ const RedditContent = class RedditContent {
   */
   fetch () {
     if (!this._fetch) {
-      this._fetch = this._r._promiseWrap(this._r._get({uri: this._uri}).then(res => this._transformApiResponse(res)));
+      if (this.constructor._name === 'Submission' && this.sort) {
+        this._fetch = this._r._promiseWrap(this._r._get({uri: this._uri, qs: { sort: this.sort } }).then(res => this._transformApiResponse(res)));
+      } else {
+        this._fetch = this._r._promiseWrap(this._r._get({uri: this._uri}).then(res => this._transformApiResponse(res)));
+      }
     }
     return this._fetch;
   }

--- a/src/snoowrap.d.ts
+++ b/src/snoowrap.d.ts
@@ -98,7 +98,7 @@ declare class Snoowrap {
   getSavedCategories(): Promise<any[]>;
   getSentMessages(options?: ListingOptions): Promise<_Listing<_PrivateMessage>>;
   getStickiedLivethread(): Promise<_LiveThread | undefined>;
-  getSubmission(submissionId: string): _Submission;
+  getSubmission(submissionId: string, sort?: string): _Submission;
   getSubreddit(displayName: string): _Subreddit;
   getSubscriptions(options?: ListingOptions): _Listing<_Subreddit>;
   getTop(subredditName?: string, options?: SortedListingOptions): Promise<_Listing<_Submission>>;

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -454,8 +454,8 @@ const snoowrap = class snoowrap {
    * r.getSubmission('2np694').title.then(console.log)
    * // => 'What tasty food would be distusting if eaten over rice?'
    */
-  getSubmission (submissionId) {
-    return this._newObject('Submission', {name: addFullnamePrefix(submissionId, 't3_')});
+  getSubmission (submissionId, sort = null) {
+    return this._newObject('Submission', {name: addFullnamePrefix(submissionId, 't3_'), sort});
   }
 
   /**

--- a/src/snoowrap.js
+++ b/src/snoowrap.js
@@ -446,6 +446,7 @@ const snoowrap = class snoowrap {
   /**
    * @summary Gets information on a given submission.
    * @param {string} submissionId - The base36 id of the submission
+   * @param {string} sort - How to sort the comments
    * @returns {Submission} An unfetched Submission object for the requested submission
    * @example
    *


### PR DESCRIPTION
As the title suggests, this PR adds the ability to pass in the sorting type you want for comments when you use `getSubmission`. 